### PR TITLE
chore: change of ownership from developer-productivity to sre

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Tradeshift/developer-productivity @Tradeshift/ci-workers
+* @Tradeshift/sre @Tradeshift/ci-workers

--- a/Repofile
+++ b/Repofile
@@ -1,6 +1,6 @@
 {
     "maintainers": [
-        "developer-productivity"
+        "sre"
     ],
     "topics": [
         "github-action"

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -10,5 +10,5 @@ metadata:
     - github-action
 spec:
   type: library
-  owner: developer-productivity
+  owner: sre
   lifecycle: production


### PR DESCRIPTION
This PR changes the ownership of this repo to SRE, as the developer productivity team doesn't exist anymore.